### PR TITLE
Network deep linking support

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,12 +97,46 @@ createApp({
         const isWalletInitialized = ref(false);
         let allowedRpcEndpoint = null;
 
+        // Deep linking helper functions
+        const getNetworkFromUrl = () => {
+            const urlParams = new URLSearchParams(window.location.search);
+            return urlParams.get('network');
+        };
+
+        const updateUrlWithNetwork = (networkId) => {
+            const url = new URL(window.location.href);
+            if (networkId && networkId !== 'base') {
+                // Only add to URL if not the default network
+                url.searchParams.set('network', networkId);
+            } else {
+                // Remove param if it's the default network
+                url.searchParams.delete('network');
+            }
+            // Update URL without reloading the page
+            window.history.replaceState({}, '', url.toString());
+        };
+
         // Lifecycle
         onMounted(() => {
             // Initialize theme
             document.documentElement.setAttribute('data-bs-theme', currentTheme.value);
             updateWalletStateUI();
-            networkStatusText.value = `Selected Network: ${getNetworkName()} (Default)`;
+            
+            // Check for network in URL (deep linking support)
+            const urlNetwork = getNetworkFromUrl();
+            if (urlNetwork) {
+                const networkExists = availableNetworks.value.some(n => n.id === urlNetwork);
+                if (networkExists) {
+                    selectedNetwork.value = urlNetwork;
+                    // Update RPC endpoint for the selected network
+                    const network = availableNetworks.value.find(n => n.id === urlNetwork);
+                    if (network && network.id !== 'custom') {
+                        rpcEndpoint.value = network.rpcUrl;
+                    }
+                }
+            }
+            
+            networkStatusText.value = `Selected Network: ${getNetworkName()}${urlNetwork ? '' : ' (Default)'}`;
             networkStatusClass.value = 'form-text text-primary d-block mt-2';
             
             // Listen for Receive tab being shown to generate QR codes
@@ -730,6 +764,9 @@ createApp({
             if (network && network.id !== 'custom') {
                 rpcEndpoint.value = network.rpcUrl;
             }
+            
+            // Update URL for deep linking support
+            updateUrlWithNetwork(selectedNetwork.value);
             
             networkStatusText.value = `Selected Network: ${getNetworkName()}`;
             networkStatusClass.value = 'form-text text-primary d-block mt-2';

--- a/app.js
+++ b/app.js
@@ -123,20 +123,22 @@ createApp({
             updateWalletStateUI();
             
             // Check for network in URL (deep linking support)
+            // Only support known networks, ignore unknown network values
             const urlNetwork = getNetworkFromUrl();
+            let validNetworkFromUrl = false;
+            
             if (urlNetwork) {
-                const networkExists = availableNetworks.value.some(n => n.id === urlNetwork);
-                if (networkExists) {
+                // Only apply if it's a known network (excluding 'custom')
+                const network = availableNetworks.value.find(n => n.id === urlNetwork && n.id !== 'custom');
+                if (network) {
+                    validNetworkFromUrl = true;
                     selectedNetwork.value = urlNetwork;
-                    // Update RPC endpoint for the selected network
-                    const network = availableNetworks.value.find(n => n.id === urlNetwork);
-                    if (network && network.id !== 'custom') {
-                        rpcEndpoint.value = network.rpcUrl;
-                    }
+                    rpcEndpoint.value = network.rpcUrl;
                 }
+                // If unknown network in URL, silently fall back to default (base)
             }
             
-            networkStatusText.value = `Selected Network: ${getNetworkName()}${urlNetwork ? '' : ' (Default)'}`;
+            networkStatusText.value = `Selected Network: ${getNetworkName()}${validNetworkFromUrl ? '' : ' (Default)'}`;
             networkStatusClass.value = 'form-text text-primary d-block mt-2';
             
             // Listen for Receive tab being shown to generate QR codes


### PR DESCRIPTION
Add deep linking support for network selection to allow sharing of pre-configured network links.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4623979-341c-4355-b77c-118f07a9683c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4623979-341c-4355-b77c-118f07a9683c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds URL-based network selection via `?network=` and keeps the URL updated when users switch networks.
> 
> - **Deep Linking (app.js)**
>   - Add helpers `getNetworkFromUrl` and `updateUrlWithNetwork` for parsing/updating `?network=`.
>   - On mount: read `?network=` to preselect `selectedNetwork` and set `rpcEndpoint` for known networks.
>   - On network change (`updateRpcEndpoint`): update the URL to reflect the current network (omit for default `base`).
>   - Update `networkStatusText` to indicate default only when no URL param is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5be5ab76e8920f8cfd24f8f5c6cae8a624844bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->