### PR TITLE
Add Robinhood Chain mainnet and testnet with official RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ The wallet includes pre-configured support for:
 | Base | ETH | 8453 | https://mainnet.base.org |
 | Sepolia Testnet | ETH | 11155111 | https://1rpc.io/sepolia |
 | Robinhood Chain | ETH | 4663 | https://rpc.mainnet.chain.robinhood.com |
-| Robinhood Chain Testnet | ETH | 46630 | https://rpc.testnet.chain.robinhood.com |
 | Custom | Various | Various | User-defined |
 
 ## 🛠️ Development

--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ The wallet includes pre-configured support for:
 | Optimism | ETH | 10 | https://mainnet.optimism.io |
 | Base | ETH | 8453 | https://mainnet.base.org |
 | Sepolia Testnet | ETH | 11155111 | https://1rpc.io/sepolia |
+| Robinhood Chain | ETH | 4663 | https://rpc.mainnet.chain.robinhood.com |
+| Robinhood Chain Testnet | ETH | 46630 | https://rpc.testnet.chain.robinhood.com |
 | Custom | Various | Various | User-defined |
 
 ## 🛠️ Development
 
 ### Customization
-- **Add Networks**: Edit the `availableNetworks` array in `index.html`
+- **Add Networks**: Edit the `availableNetworks` array in `app.js`
 
 ## 🔒 Security Considerations
 

--- a/app.js
+++ b/app.js
@@ -60,11 +60,6 @@ createApp({
                 rpcUrl: 'https://rpc.mainnet.chain.robinhood.com'
             },
             {
-                id: 'robinhood-testnet',
-                name: 'Robinhood Chain Testnet',
-                rpcUrl: 'https://rpc.testnet.chain.robinhood.com'
-            },
-            {
                 id: 'custom',
                 name: 'Custom',
                 rpcUrl: ''
@@ -243,8 +238,7 @@ createApp({
                     'optimism': { name: 'Optimism', chainId: 10, nativeSymbol: 'ETH' },
                     'polygon': { name: 'Polygon', chainId: 137, nativeSymbol: 'MATIC' },
                     'arbitrum': { name: 'Arbitrum One', chainId: 42161, nativeSymbol: 'ETH' },
-                    'robinhood-mainnet': { name: 'Robinhood Chain', chainId: 4663, nativeSymbol: 'ETH' },
-                    'robinhood-testnet': { name: 'Robinhood Chain Testnet', chainId: 46630, nativeSymbol: 'ETH' }
+                    'robinhood-mainnet': { name: 'Robinhood Chain', chainId: 4663, nativeSymbol: 'ETH' }
                 };
                 
                 chainInfo.value = networkConfig[selectedNetwork.value] || { name: 'Unknown Chain', chainId: 0, nativeSymbol: 'ETH' };
@@ -275,7 +269,6 @@ createApp({
                     100: 'XDAI',   // Gnosis Chain
                     42220: 'CELO', // Celo
                     4663: 'ETH',   // Robinhood Chain
-                    46630: 'ETH',  // Robinhood Chain Testnet
                 };
 
                 chainInfo.value = {
@@ -395,9 +388,6 @@ createApp({
                                 break;
                             case 'robinhood-mainnet':
                                 networkInfo = ethers.Network.from({ name: 'robinhood', chainId: 4663 });
-                                break;
-                            case 'robinhood-testnet':
-                                networkInfo = ethers.Network.from({ name: 'robinhood-testnet', chainId: 46630 });
                                 break;
                             default:
                                 networkInfo = null;

--- a/app.js
+++ b/app.js
@@ -55,6 +55,16 @@ createApp({
                 rpcUrl: 'https://arb1.arbitrum.io/rpc'
             },
             {
+                id: 'robinhood-mainnet',
+                name: 'Robinhood Chain',
+                rpcUrl: 'https://rpc.mainnet.chain.robinhood.com'
+            },
+            {
+                id: 'robinhood-testnet',
+                name: 'Robinhood Chain Testnet',
+                rpcUrl: 'https://rpc.testnet.chain.robinhood.com'
+            },
+            {
                 id: 'custom',
                 name: 'Custom',
                 rpcUrl: ''
@@ -232,7 +242,9 @@ createApp({
                     'base': { name: 'Base', chainId: 8453, nativeSymbol: 'ETH' },
                     'optimism': { name: 'Optimism', chainId: 10, nativeSymbol: 'ETH' },
                     'polygon': { name: 'Polygon', chainId: 137, nativeSymbol: 'MATIC' },
-                    'arbitrum': { name: 'Arbitrum One', chainId: 42161, nativeSymbol: 'ETH' }
+                    'arbitrum': { name: 'Arbitrum One', chainId: 42161, nativeSymbol: 'ETH' },
+                    'robinhood-mainnet': { name: 'Robinhood Chain', chainId: 4663, nativeSymbol: 'ETH' },
+                    'robinhood-testnet': { name: 'Robinhood Chain Testnet', chainId: 46630, nativeSymbol: 'ETH' }
                 };
                 
                 chainInfo.value = networkConfig[selectedNetwork.value] || { name: 'Unknown Chain', chainId: 0, nativeSymbol: 'ETH' };
@@ -262,6 +274,8 @@ createApp({
                     59144: 'ETH',  // Linea
                     100: 'XDAI',   // Gnosis Chain
                     42220: 'CELO', // Celo
+                    4663: 'ETH',   // Robinhood Chain
+                    46630: 'ETH',  // Robinhood Chain Testnet
                 };
 
                 chainInfo.value = {
@@ -378,6 +392,12 @@ createApp({
                                 break;
                             case 'arbitrum':
                                 networkInfo = ethers.Network.from({ name: 'arbitrum', chainId: 42161 });
+                                break;
+                            case 'robinhood-mainnet':
+                                networkInfo = ethers.Network.from({ name: 'robinhood', chainId: 4663 });
+                                break;
+                            case 'robinhood-testnet':
+                                networkInfo = ethers.Network.from({ name: 'robinhood-testnet', chainId: 46630 });
                                 break;
                             default:
                                 networkInfo = null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds first-class support for Robinhood Chain mainnet using the official public RPC endpoint from [Robinhood Chain docs](https://docs.robinhood.com/chain/connecting/).

## Network added

| Network | Chain ID | RPC |
|---------|----------|-----|
| Robinhood Chain | 4663 | `https://rpc.mainnet.chain.robinhood.com` |

## Changes

- **`app.js`**: Added Robinhood Chain mainnet to `availableNetworks`, `networkConfig`, `chainToSymbol`, and the static `ethers.Network` provider setup used during wallet initialization.
- **`README.md`**: Documented the new network and corrected the customization note to point at `app.js` instead of `index.html`.

## Usage

- Select **Robinhood Chain** from the network dropdown.
- Deep link support: `?network=robinhood-mainnet`.

## Notes

Robinhood's public RPC endpoint is rate-limited and intended for development/testing. For production workloads, consider a dedicated provider (e.g. Alchemy).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27ce-6051-791d-9821-156a1ffba289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27ce-6051-791d-9821-156a1ffba289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

