### PR TITLE
Add deploy-time cache busting for app.js and styles.css

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Inject cache-busting version
+        run: |
+          VERSION="${GITHUB_SHA:0:7}"
+          sed -i "s/__CACHE_VERSION__/${VERSION}/g" index.html
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Ethereum Wallet (Testing Only)</title>
     <link rel="stylesheet" href="libs/bootstrap-5.3.3.min.css">
     <link rel="stylesheet" href="libs/bootstrap-icons-1.11.3.min.css">
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=__CACHE_VERSION__">
     <script src="libs/ethers-6.13.5-ethers.umd.min.js"></script>
     <script src="libs/vue-3.5.13-vue.global.prod.min.js"></script>
 </head>
@@ -253,6 +253,6 @@
     <!-- Add QR Code Library -->
     <script src="libs/qrcode-1.0.0.min.js"></script>
     <!-- Main Application -->
-    <script src="app.js"></script>
+    <script src="app.js?v=__CACHE_VERSION__"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automatic cache busting for mutable app assets so browsers load the latest code after each deploy.

## How it works

- `index.html` references `app.js` and `styles.css` with a `?v=__CACHE_VERSION__` placeholder.
- The GitHub Pages deploy workflow replaces that placeholder with the first 7 characters of the commit SHA before uploading the artifact.

Example deployed URLs:
- `app.js?v=319e05d`
- `styles.css?v=319e05d`

Vendored libraries under `libs/` are unchanged (already versioned in filenames).

## Why

Users were not seeing newly deployed network options (e.g. Robinhood Chain) until a hard refresh because `app.js` was cached by the browser/CDN.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f27ce-6051-791d-9821-156a1ffba289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f27ce-6051-791d-9821-156a1ffba289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

