### PR TITLE
Group networks into Testnets/Mainnets and align README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern, self-contained Ethereum wallet application built for testing and devel
 
 ## ⚠️ **Critical Security Warning**
 
-**THIS WALLET IS FOR TESTING PURPOSES ONLY.** Never use it with real funds or on mainnet. Always use testnets and test tokens. This application stores private keys in browser memory and should never be used for production or real cryptocurrency transactions.
+**THIS WALLET IS FOR TESTING AND DEVELOPMENT USE.** It stores private keys in browser memory only and is not a production custody wallet. Do not use it to hold large amounts of cryptocurrency or as a long-term wallet. Prefer small amounts and clear the session when you are done.
 
 ## ✨ Key Features
 
@@ -15,13 +15,14 @@ A modern, self-contained Ethereum wallet application built for testing and devel
 - **Secure Key Display** - Show/hide private keys and seed phrases with copy functionality
 
 ### 🌐 Multi-Chain Support
-- **Pre-configured Networks** - Ethereum, Polygon,  Arbitrum, Optimism, Base, and more
+- **Pre-configured Networks** - Ethereum, Polygon, Arbitrum, Optimism, Base, Sepolia, and more
+- **Grouped Network Picker** - Networks organized into Testnets, Mainnets, and Custom (default: Base)
 - **Custom RPC Support** - Add any EVM-compatible network
 - **Automatic Network Detection** - Smart detection of network parameters
-- **Native Token Recognition** - Automatic detection of native tokens (ETH, MATIC, etc.)
+- **Native Token Recognition** - Automatic detection of native tokens (ETH, POL, etc.)
 
 ### 💸 Transaction Features
-- **Native Token Transfers** - Send ETH, MATIC, and other native tokens
+- **Native Token Transfers** - Send ETH, POL, and other native tokens
 - **Real-time Gas Estimation** - Accurate gas cost calculation with safety buffer
 - **Transaction Status** - Live transaction status updates
 
@@ -56,7 +57,7 @@ Then visit `http://localhost:8000` in your browser.
 ### Getting Started
 
 1. **Network Configuration**
-   - Select a network from the dropdown (Ethereum, Polygon, etc.)
+   - Select a network from the dropdown (grouped as Testnets, Mainnets, or Custom; default is Base)
    - Or enter a custom RPC endpoint
    - The wallet will automatically detect network parameters
 
@@ -108,23 +109,23 @@ libs/
 ```
 
 ### Supported Networks
-The wallet includes pre-configured support for:
+The wallet includes pre-configured support for the networks below. In the UI they are grouped as Testnets, Mainnets, and Custom. **Base** is the default network.
 
-| Network | Native Token | Chain ID | RPC Endpoint |
-|---------|-------------|----------|--------------|
-| Ethereum | ETH | 1 | https://eth.drpc.org |
-| Polygon | MATIC | 137 | https://polygon-rpc.com |
-| Arbitrum | ETH | 42161 | https://arb1.arbitrum.io/rpc |
-| Optimism | ETH | 10 | https://mainnet.optimism.io |
-| Base | ETH | 8453 | https://mainnet.base.org |
-| Sepolia Testnet | ETH | 11155111 | https://1rpc.io/sepolia |
-| Robinhood Chain | ETH | 4663 | https://rpc.mainnet.chain.robinhood.com |
-| Custom | Various | Various | User-defined |
+| Network | Native Token | Chain ID | RPC Endpoint | Group |
+|---------|-------------|----------|--------------|-------|
+| Sepolia Testnet | ETH | 11155111 | https://1rpc.io/sepolia | Testnet |
+| Ethereum | ETH | 1 | https://eth.drpc.org | Mainnet |
+| Base (default) | ETH | 8453 | https://mainnet.base.org | Mainnet |
+| Optimism | ETH | 10 | https://mainnet.optimism.io | Mainnet |
+| Polygon | POL | 137 | https://polygon-rpc.com | Mainnet |
+| Arbitrum | ETH | 42161 | https://arb1.arbitrum.io/rpc | Mainnet |
+| Robinhood Chain | ETH | 4663 | https://rpc.mainnet.chain.robinhood.com | Mainnet |
+| Custom | Various | Various | User-defined | Other |
 
 ## 🛠️ Development
 
 ### Customization
-- **Add Networks**: Edit the `availableNetworks` array in `app.js`
+- **Add Networks**: Edit the `availableNetworks` array in `app.js` (set `isTestnet` for grouping)
 
 ## 🔒 Security Considerations
 
@@ -142,10 +143,10 @@ The wallet includes pre-configured support for:
 - ✅ Provide clear security warnings
 
 ### Best Practices
-1. **Only use on testnets** - Never use with real funds
+1. **Treat this as a testing tool** - Prefer small amounts; do not use it for long-term custody
 2. **Clear session after use** - Use the "Clear Wallet Session" button
-4. **Test transactions** - Start with small amounts on testnets
-5. **Backup seed phrases** - Store seed phrases securely offline
+3. **Double-check the network** - Confirm Testnet vs Mainnet before sending
+4. **Backup seed phrases** - Store seed phrases securely offline
 
 ## 📄 License
 
@@ -153,4 +154,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-**⚠️ FINAL REMINDER: This is a testing and development tool. Never use it with real cryptocurrency or on production networks. Always use testnets and test tokens.**
+**⚠️ FINAL REMINDER: This is a testing and development tool with in-memory keys. It is not a production custody wallet—use carefully and clear your session when finished.**

--- a/app.js
+++ b/app.js
@@ -27,37 +27,44 @@ createApp({
             {
                 id: 'ethereum',
                 name: 'Ethereum Mainnet',
-                rpcUrl: 'https://eth.drpc.org'
+                rpcUrl: 'https://eth.drpc.org',
+                isTestnet: false
             },
             {
                 id: 'sepolia',
                 name: 'Sepolia Testnet',
-                rpcUrl: 'https://1rpc.io/sepolia'
+                rpcUrl: 'https://1rpc.io/sepolia',
+                isTestnet: true
             },
             {
                 id: 'base',
                 name: 'Base',
-                rpcUrl: 'https://mainnet.base.org'
+                rpcUrl: 'https://mainnet.base.org',
+                isTestnet: false
             },
             {
                 id: 'optimism',
                 name: 'Optimism',
-                rpcUrl: 'https://mainnet.optimism.io'
+                rpcUrl: 'https://mainnet.optimism.io',
+                isTestnet: false
             },
             {
                 id: 'polygon',
                 name: 'Polygon',
-                rpcUrl: 'https://polygon-rpc.com'
+                rpcUrl: 'https://polygon-rpc.com',
+                isTestnet: false
             },
             {
                 id: 'arbitrum',
                 name: 'Arbitrum One',
-                rpcUrl: 'https://arb1.arbitrum.io/rpc'
+                rpcUrl: 'https://arb1.arbitrum.io/rpc',
+                isTestnet: false
             },
             {
                 id: 'robinhood-mainnet',
                 name: 'Robinhood Chain',
-                rpcUrl: 'https://rpc.mainnet.chain.robinhood.com'
+                rpcUrl: 'https://rpc.mainnet.chain.robinhood.com',
+                isTestnet: false
             },
             {
                 id: 'custom',
@@ -65,6 +72,13 @@ createApp({
                 rpcUrl: ''
             }
         ]);
+
+        const testnetNetworks = computed(() =>
+            availableNetworks.value.filter(n => n.id !== 'custom' && n.isTestnet)
+        );
+        const mainnetNetworks = computed(() =>
+            availableNetworks.value.filter(n => n.id !== 'custom' && !n.isTestnet)
+        );
         
         const walletStatus = ref('');
         const error = ref('');
@@ -236,7 +250,7 @@ createApp({
                     'sepolia': { name: 'Sepolia Testnet', chainId: 11155111, nativeSymbol: 'ETH' },
                     'base': { name: 'Base', chainId: 8453, nativeSymbol: 'ETH' },
                     'optimism': { name: 'Optimism', chainId: 10, nativeSymbol: 'ETH' },
-                    'polygon': { name: 'Polygon', chainId: 137, nativeSymbol: 'MATIC' },
+                    'polygon': { name: 'Polygon', chainId: 137, nativeSymbol: 'POL' },
                     'arbitrum': { name: 'Arbitrum One', chainId: 42161, nativeSymbol: 'ETH' },
                     'robinhood-mainnet': { name: 'Robinhood Chain', chainId: 4663, nativeSymbol: 'ETH' }
                 };
@@ -258,7 +272,7 @@ createApp({
                 const chainToSymbol = {
                     1: 'ETH',      // Ethereum Mainnet
                     11155111: 'ETH', // Sepolia Testnet
-                    137: 'MATIC',  // Polygon
+                    137: 'POL',    // Polygon
                     56: 'BNB',     // BSC
                     43114: 'AVAX', // Avalanche
                     42161: 'ETH',  // Arbitrum
@@ -818,6 +832,8 @@ createApp({
             tabs,
             selectedNetwork,
             availableNetworks,
+            testnetNetworks,
+            mainnetNetworks,
             rpcEndpoint,
             seedPhrase,
             seedVisible,

--- a/index.html
+++ b/index.html
@@ -67,9 +67,19 @@
                                 <div class="mb-3">
                                     <label for="network-select" class="form-label">Network</label>
                                     <select class="form-select mb-2" id="network-select" v-model="selectedNetwork" @change="updateRpcEndpoint">
-                                        <option v-for="network in availableNetworks" :key="network.id" :value="network.id">
-                                            {{ network.name }}
-                                        </option>
+                                        <optgroup label="Testnets">
+                                            <option v-for="network in testnetNetworks" :key="network.id" :value="network.id">
+                                                {{ network.name }}
+                                            </option>
+                                        </optgroup>
+                                        <optgroup label="Mainnets">
+                                            <option v-for="network in mainnetNetworks" :key="network.id" :value="network.id">
+                                                {{ network.name }}
+                                            </option>
+                                        </optgroup>
+                                        <optgroup label="Other">
+                                            <option value="custom">Custom</option>
+                                        </optgroup>
                                     </select>
                                 </div>
                                 <div class="mb-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Group the network picker into **Testnets**, **Mainnets**, and **Other (Custom)** via `isTestnet` metadata on presets
- Keep **Base** as the default network (no default change, no mainnet send confirmation)
- Rename Polygon native symbol **MATIC → POL** in chain info and custom RPC symbol map
- Soften README security language so it no longer claims testnet-only use, while still warning this is an in-memory testing/dev wallet

## Test plan

- [ ] Load app with no query params → Base is selected, URL has no `?network=`
- [ ] Network dropdown shows Testnets → Mainnets → Other (Custom)
- [ ] `?network=sepolia` still deep-links to Sepolia
- [ ] Send on Base/Ethereum → no confirmation dialog
- [ ] Select Polygon → native symbol shows `POL`
- [ ] README no longer says “never use on mainnet” / “always use testnets”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

