### PR TITLE
Add block explorer link after sending a transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A modern, self-contained Ethereum wallet application built for testing and devel
 ### 💸 Transaction Features
 - **Native Token Transfers** - Send ETH, POL, and other native tokens
 - **Real-time Gas Estimation** - Accurate gas cost calculation with safety buffer
-- **Transaction Status** - Live transaction status updates
+- **Transaction Status** - Live transaction status updates with a block explorer link after send
 
 ### 🔒 Self-Contained
 - **No CDN Dependencies** - All libraries stored locally
@@ -78,6 +78,7 @@ Then visit `http://localhost:8000` in your browser.
 - Select the sending address from your accounts
 - Enter recipient address and amount
 - Review gas costs and confirm transaction
+- After sending, open the transaction on the network's block explorer (Etherscan, Basescan, etc.)
 
 #### Receive Tab
 - View QR codes for all your addresses

--- a/app.js
+++ b/app.js
@@ -91,8 +91,20 @@ createApp({
         const amount = ref('');
         const txStatus = ref('');
         const txStatusType = ref(''); // 'success', 'error', or ''
+        const txExplorerUrl = ref('');
         const estimatedGas = ref('');
         const tokenInfo = ref(null);
+
+        // Block explorer base URLs by network id (append tx hash)
+        const EXPLORER_TX_URLS = {
+            ethereum: 'https://etherscan.io/tx/',
+            sepolia: 'https://sepolia.etherscan.io/tx/',
+            base: 'https://basescan.org/tx/',
+            optimism: 'https://optimistic.etherscan.io/tx/',
+            polygon: 'https://polygonscan.com/tx/',
+            arbitrum: 'https://arbiscan.io/tx/',
+            'robinhood-mainnet': 'https://robinhoodchain.blockscout.com/tx/'
+        };
         
         // Timeout for auto-clearing error messages
         let txStatusTimeout = null;
@@ -344,6 +356,14 @@ createApp({
             }
         };
 
+        const getTxExplorerUrl = (txHash) => {
+            if (!txHash || selectedNetwork.value === 'custom') {
+                return '';
+            }
+            const baseUrl = EXPLORER_TX_URLS[selectedNetwork.value];
+            return baseUrl ? `${baseUrl}${txHash}` : '';
+        };
+
         const clearSession = () => {
             wallets.value.length = 0;
             walletPrivateKeys.length = 0;
@@ -353,6 +373,7 @@ createApp({
             tokenInfo.value = null;
             txStatus.value = '';
             txStatusType.value = '';
+            txExplorerUrl.value = '';
             if (txStatusTimeout) {
                 clearTimeout(txStatusTimeout);
                 txStatusTimeout = null;
@@ -429,6 +450,7 @@ createApp({
                 tokenInfo.value = null;
                 txStatus.value = '';
                 txStatusType.value = '';
+                txExplorerUrl.value = '';
                 if (txStatusTimeout) {
                     clearTimeout(txStatusTimeout);
                     txStatusTimeout = null;
@@ -617,6 +639,7 @@ createApp({
                 isLoading.value = true;
                 txStatus.value = 'Preparing transaction...';
                 txStatusType.value = 'success';
+                txExplorerUrl.value = '';
 
                 const walletIndex = accounts.value.find(acc => acc.address === selectedFromAddress.value)?.index;
                 if (walletIndex === undefined) {
@@ -665,6 +688,7 @@ createApp({
                     tx = await connectedWallet.sendTransaction(transferTx);
                 }
 
+                txExplorerUrl.value = getTxExplorerUrl(tx.hash);
                 txStatus.value = `Transaction sent! Hash: ${tx.hash}`;
                 txStatusType.value = 'success';
                 await tx.wait();
@@ -674,11 +698,13 @@ createApp({
             } catch (err) {
                 txStatus.value = 'Transaction failed: ' + err.message;
                 txStatusType.value = 'error';
+                txExplorerUrl.value = '';
                 
                 // Auto-clear error messages after 10 seconds
                 txStatusTimeout = setTimeout(() => {
                     txStatus.value = '';
                     txStatusType.value = '';
+                    txExplorerUrl.value = '';
                     txStatusTimeout = null;
                 }, 10000);
             } finally {
@@ -847,6 +873,7 @@ createApp({
             amount,
             txStatus,
             txStatusType,
+            txExplorerUrl,
             estimatedGas,
             chainInfo,
             tokenInfo,

--- a/index.html
+++ b/index.html
@@ -224,6 +224,11 @@
 
                              <div v-if="txStatus" :class="['alert', txStatusType === 'error' ? 'alert-danger' : 'alert-success', 'mt-3']">
                                 <strong>Transaction Status:</strong> {{ txStatus }}
+                                <div v-if="txExplorerUrl" class="mt-2">
+                                    <a :href="txExplorerUrl" target="_blank" rel="noopener noreferrer" class="alert-link">
+                                        <i class="bi bi-box-arrow-up-right me-1"></i>View on block explorer
+                                    </a>
+                                </div>
                              </div>
                         </div>
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- After a successful send, show a **View on block explorer** link next to the transaction status
- Map known networks to their explorers (Etherscan, Sepolia Etherscan, Basescan, Optimistic Etherscan, Polygonscan, Arbiscan, Robinhood Blockscout)
- Custom RPC networks omit the link (no known explorer)
- No transaction history list — explorer link only

## Test plan

- [ ] Send a tx on Base → status shows link to `basescan.org/tx/<hash>`
- [ ] Send on Sepolia → link goes to `sepolia.etherscan.io`
- [ ] Send on Ethereum → link goes to `etherscan.io`
- [ ] Custom RPC → no explorer link shown
- [ ] Failed send → no explorer link; error clears as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

