### PR TITLE
Add in-session previous wallet reconnect dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern, self-contained Ethereum wallet application built for testing and devel
 - **Import Existing Wallets** - Support for both private keys and seed phrases
 - **Multiple Account Support** - Manage multiple accounts from a single seed phrase
 - **Secure Key Display** - Show/hide private keys and seed phrases with copy functionality
+- **In-session Reconnect** - Reuse keys/phrases from earlier imports on the same page load (memory only; cleared on refresh)
 
 ### 🌐 Multi-Chain Support
 - **Pre-configured Networks** - Ethereum, Polygon, Arbitrum, Optimism, Base, Sepolia, and more
@@ -65,6 +66,7 @@ Then visit `http://localhost:8000` in your browser.
    - **New Wallet**: Click "Generate New Wallet" to create a fresh wallet
    - **Import Wallet**: Enter your seed phrase or private key and click "Import"
    - Your wallet will initialize and display all available accounts
+   - After clearing a session, use **Previous sessions (this page)** to reconnect a recently used key or phrase (lost on refresh)
 
 ### Using the Wallet
 

--- a/app.js
+++ b/app.js
@@ -29,6 +29,9 @@ createApp({
         const rpcEndpoint = ref('https://mainnet.base.org');
         const seedPhrase = ref('');
         const seedVisible = ref(false);
+        // In-memory only; cleared automatically on page refresh
+        const previousSessions = ref([]);
+        const selectedPreviousSession = ref('');
         
         // Available networks with their RPC endpoints
         const availableNetworks = ref([
@@ -339,6 +342,38 @@ createApp({
 
         const getTxExplorerUrl = (txHash) => buildTxExplorerUrl(txHash, selectedNetwork.value);
 
+        const rememberPreviousSession = (secret, address) => {
+            if (!secret || !address) {
+                return;
+            }
+
+            previousSessions.value = previousSessions.value.filter(
+                (session) => session.secret !== secret
+            );
+
+            previousSessions.value.unshift({
+                id: `${Date.now()}-${address}`,
+                secret,
+                address,
+                type: secret.includes(' ') ? 'mnemonic' : 'privateKey'
+            });
+
+            selectedPreviousSession.value = '';
+        };
+
+        const reconnectPreviousSession = async () => {
+            const session = previousSessions.value.find(
+                (entry) => entry.id === selectedPreviousSession.value
+            );
+            if (!session) {
+                return;
+            }
+
+            seedPhrase.value = session.secret;
+            await initializeWallet();
+            selectedPreviousSession.value = '';
+        };
+
         const clearSession = () => {
             wallets.value.length = 0;
             walletPrivateKeys.length = 0;
@@ -360,6 +395,8 @@ createApp({
             currentPrivateKey.value = '';
             originalSeedInput.value = '';
             isPrivateKeyVisible.value = false;
+            selectedPreviousSession.value = '';
+            // Keep previousSessions so the user can reconnect without retyping
             updateWalletStateUI();
             showAlert('Wallet session cleared.', 'info');
         };
@@ -462,6 +499,10 @@ createApp({
                 isWalletInitialized.value = true;
                 updateWalletStateUI();
                 walletStatus.value = '';
+                rememberPreviousSession(
+                    originalSeedInput.value,
+                    wallets.value[0]?.address || accounts.value[0]?.address
+                );
                 showAlert('Wallet initialized successfully!', 'success');
                 
             } catch (err) {
@@ -838,6 +879,8 @@ createApp({
             rpcEndpoint,
             seedPhrase,
             seedVisible,
+            previousSessions,
+            selectedPreviousSession,
             walletStatus,
             error,
             accounts,
@@ -862,6 +905,7 @@ createApp({
             toggleCurrentPrivateKeyVisibility,
             copyPrivateKey,
             clearSession,
+            reconnectPreviousSession,
             initializeWallet,
             updateTokenBalance,
             estimateGas,

--- a/index.html
+++ b/index.html
@@ -119,6 +119,25 @@
                                              </button>
                                          </div>
                                     </form>
+                                    <div class="mb-3" v-if="previousSessions.length">
+                                        <label for="previous-session-select" class="form-label">Previous sessions (this page)</label>
+                                        <select
+                                            class="form-select"
+                                            id="previous-session-select"
+                                            v-model="selectedPreviousSession"
+                                            @change="reconnectPreviousSession"
+                                        >
+                                            <option disabled value="">Select a previous key or phrase…</option>
+                                            <option
+                                                v-for="(session, index) in previousSessions"
+                                                :key="session.id"
+                                                :value="session.id"
+                                            >
+                                                {{ index + 1 }}. {{ formatAddressShort(session.address) }}
+                                            </option>
+                                        </select>
+                                        <small class="form-text text-muted">Remembered until you refresh the page.</small>
+                                    </div>
                                 </div>
 
                                <!-- Loaded Wallet Info Section -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- After a successful import or generate, remember that secret **in page memory only**
- Under the seed/private-key row, show **Previous sessions (this page)** as `1. 0xabcd...ef12`
- Selecting an entry reconnects that wallet
- **Clear Wallet Session** keeps the list; a full page refresh clears it
- Duplicate secrets are deduped (newest use moves to the top)

## Test plan

- [ ] Generate wallet A → Clear session → dropdown shows `1. 0x…` → select → same accounts reload
- [ ] Import a second wallet → two numbered entries, newest first
- [ ] Re-import the same secret → still one entry
- [ ] Refresh the page → dropdown is gone
- [ ] Mainnets/send/explorer behavior unchanged
- [ ] `npm test` / CI `unit-tests` green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

