### PR TITLE
Show shortened secret in previous-session dropdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,13 +188,19 @@ createApp({
             return network ? network.name : 'Unknown';
         };
 
-        // Computed property for masked private key display
+        // Same shortening used for session key display (private key or seed phrase)
+        const formatSecretShort = (secret) => {
+            if (!secret || secret.length < 10) return secret || '***';
+            return `${secret.substring(0, 6)}...${secret.substring(secret.length - 6)}`;
+        };
+
+        // Computed property for masked private key / seed phrase display
         const currentPrivateKeyDisplay = computed(() => {
             if (!originalSeedInput.value || originalSeedInput.value.length < 10) return '***';
             if (isPrivateKeyVisible.value) {
                 return originalSeedInput.value;
             }
-            return `${originalSeedInput.value.substring(0, 6)}...${originalSeedInput.value.substring(originalSeedInput.value.length - 6)}`;
+            return formatSecretShort(originalSeedInput.value);
         });
 
         // Alert system
@@ -916,7 +922,8 @@ createApp({
             generateQRCode,
             generateAllQRCodes,
             updateRpcEndpoint,
-            formatAddressShort
+            formatAddressShort,
+            formatSecretShort
         };
     }
 }).mount('#app');

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                                                 :key="session.id"
                                                 :value="session.id"
                                             >
-                                                {{ index + 1 }}. {{ formatAddressShort(session.address) }}
+                                                {{ index + 1 }}. {{ formatSecretShort(session.secret) }}
                                             </option>
                                         </select>
                                         <small class="form-text text-muted">Remembered until you refresh the page.</small>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #17: the previous-sessions dropdown now labels entries with the same `first6...last6` shortening used for Current Session Key, so seed phrases and private keys appear as shortened secrets rather than account addresses.

## Verified locally

Ran the app at `http://127.0.0.1:8000` (Playwright against the static server) and `npm test`:

- Dropdown is hidden when there are no previous sessions
- Seed-phrase wallet → clear session → dropdown label matches Current Session Key masking (e.g. `1. sting ... brain`)
- Selecting that entry reconnects the seed-phrase wallet
- Private-key wallet → clear session → dropdown label matches Current Session Key masking (e.g. `1. 0x5d85...320494`)
- Selecting that entry reconnects the private-key wallet
- Both sessions appear in history (newest first)
- `npm test` passed (8 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

