### PR TITLE
Add pull request template for local verification notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What changed and why. Keep it short. -->
+
+## Verified locally
+
+<!--
+ONLY list checks you actually ran against a local build of the app (and/or npm test).
+Do NOT include speculative "test plan" checklists for reviewers to run.
+Do NOT list UI/browser steps you did not execute yourself.
+If you only ran unit tests, say that—do not invent end-to-end checks.
+-->
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,15 @@
 ## Verified locally
 
 <!--
-ONLY list checks you actually ran against a local build of the app (and/or npm test).
+Authors (including agents) MUST run local verification when possible, and cover as
+much of the changed surface area as practical (e.g. npm test, load the app locally,
+and exercise the UI/flows this PR touches).
+
+In this section, ONLY list checks you actually ran against a local build of the app
+and/or npm test.
 Do NOT include speculative "test plan" checklists for reviewers to run.
 Do NOT list UI/browser steps you did not execute yourself.
-If you only ran unit tests, say that—do not invent end-to-end checks.
+If something could not be run locally, say what was skipped and why.
 -->
 
 -


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so new PRs default to a **Verified locally** section. The template tells authors (including agents) to:

- Run local verification when possible and cover as much of the changed surface area as practical
- List only checks they actually ran
- Note anything that could not be run and why

## Verified locally

- Confirmed the template file contents at `.github/PULL_REQUEST_TEMPLATE.md` include the broader local-verification guidance
- No app UI changes; did not run the wallet app for this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

