### PR TITLE
Keep previous-session dropdown ordered oldest to newest

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A modern, self-contained Ethereum wallet application built for testing and devel
 - **Import Existing Wallets** - Support for both private keys and seed phrases
 - **Multiple Account Support** - Manage multiple accounts from a single seed phrase
 - **Secure Key Display** - Show/hide private keys and seed phrases with copy functionality
-- **In-session Reconnect** - Reuse keys/phrases from earlier imports on the same page load (memory only; cleared on refresh)
+- **In-session Reconnect** - Reuse keys/phrases from earlier imports on the same page load (memory only; cleared on refresh; listed oldest to newest)
 
 ### 🌐 Multi-Chain Support
 - **Pre-configured Networks** - Ethereum, Polygon, Arbitrum, Optimism, Base, Sepolia, and more

--- a/app.js
+++ b/app.js
@@ -353,16 +353,25 @@ createApp({
                 return;
             }
 
-            previousSessions.value = previousSessions.value.filter(
-                (session) => session.secret !== secret
+            const existingIndex = previousSessions.value.findIndex(
+                (session) => session.secret === secret
             );
 
-            previousSessions.value.unshift({
-                id: `${Date.now()}-${address}`,
-                secret,
-                address,
-                type: secret.includes(' ') ? 'mnemonic' : 'privateKey'
-            });
+            if (existingIndex !== -1) {
+                // Keep position so dropdown indices stay stable (oldest → newest)
+                previousSessions.value[existingIndex] = {
+                    ...previousSessions.value[existingIndex],
+                    address,
+                    type: secret.includes(' ') ? 'mnemonic' : 'privateKey'
+                };
+            } else {
+                previousSessions.value.push({
+                    id: `${Date.now()}-${address}`,
+                    secret,
+                    address,
+                    type: secret.includes(' ') ? 'mnemonic' : 'privateKey'
+                });
+            }
 
             selectedPreviousSession.value = '';
         };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Previous sessions are now listed **oldest → newest**. New secrets append at the end; reconnecting or re-importing an existing secret keeps its index so numbers do not jump.

## Verified locally

Ran the app at `http://127.0.0.1:8000` and `npm test`:

- First seed-phrase session appears as `1. …`
- Adding a private-key session keeps the seed at `1.` and puts the key at `2.`
- Reconnecting session `1` leaves both indices unchanged
- `npm test` passed (8 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e11a31-a4c0-4fbb-9771-74713ce3da48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

